### PR TITLE
feat: Begin migration from SpecFlow to Reqnroll for Editor UI tests

### DIFF
--- a/tests/Sitecore.Horizon.Integration.Editor.Tests.UI/CommonSteps/CommonSteps.cs
+++ b/tests/Sitecore.Horizon.Integration.Editor.Tests.UI/CommonSteps/CommonSteps.cs
@@ -13,7 +13,7 @@ using Sitecore.Horizon.Integration.Tests.Ui.Wrappers;
 using Sitecore.Horizon.Integration.Tests.Ui.Wrappers.Components.DeviceSwitcher;
 using Sitecore.Horizon.Integration.Tests.Ui.Wrappers.Components.TimedNotification;
 using Sitecore.Horizon.Integration.Tests.Ui.Wrappers.Data;
-using TechTalk.SpecFlow;
+using Reqnroll;
 
 namespace Sitecore.Horizon.Integration.Editor.Tests.UI.CommonSteps
 {

--- a/tests/Sitecore.Horizon.Integration.Editor.Tests.UI/Features/FieldsEditing/RichTextFieldSteps.cs
+++ b/tests/Sitecore.Horizon.Integration.Editor.Tests.UI/Features/FieldsEditing/RichTextFieldSteps.cs
@@ -14,7 +14,7 @@ using Sitecore.Horizon.Integration.Tests.Ui.ApiHelpers.HorizonEntities.Page;
 using Sitecore.Horizon.Integration.Tests.Ui.Wrappers.Components.MediaDialogs.ImagesDialog;
 using Sitecore.Horizon.Integration.Tests.Ui.Wrappers.Components.PageLayout.CanvasControls;
 using Sitecore.Horizon.Integration.Tests.Ui.Wrappers.Components.RightPanel;
-using TechTalk.SpecFlow;
+using Reqnroll;
 using UTF;
 using Constants = Sitecore.Horizon.Integration.Tests.Ui.Wrappers.Data.Constants;
 using Context = Sitecore.Horizon.Integration.Editor.Tests.UI.Helpers.Context;

--- a/tests/Sitecore.Horizon.Integration.Editor.Tests.UI/Helpers/TestsSetup.cs
+++ b/tests/Sitecore.Horizon.Integration.Editor.Tests.UI/Helpers/TestsSetup.cs
@@ -13,7 +13,7 @@ using Sitecore.Horizon.Integration.Tests.Ui.Wrappers.Browser;
 using Sitecore.Pages.E2EFramework.UI.Tests.ApiHelpers.EdgeGraphQL;
 using Sitecore.Pages.E2EFramework.UI.Tests.ApiHelpers.HorizonGraphQL;
 using Sitecore.Pages.E2EFramework.UI.Tests.ApiHelpers.PlatformGraphQL;
-using TechTalk.SpecFlow;
+using Reqnroll;
 using UTF;
 using UTF.HelperWebService;
 using ApiSettings = Sitecore.Pages.E2EFramework.UI.Tests.ApiHelpers.Settings;

--- a/tests/Sitecore.Horizon.Integration.Editor.Tests.UI/Sitecore.Horizon.Integration.Editor.Tests.UI.csproj
+++ b/tests/Sitecore.Horizon.Integration.Editor.Tests.UI/Sitecore.Horizon.Integration.Editor.Tests.UI.csproj
@@ -32,9 +32,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="SpecFlow" Version="3.9.58" />
-    <PackageReference Include="SpecFlow.NUnit" Version="3.9.58" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.58" />
+    <PackageReference Include="Reqnroll.NUnit" Version="1.0.1" />
+    <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="1.0.1" />
 
     <!-- Report portal packages -->
     <PackageReference Include="ReportPortal.NUnit" Version="4.4.1" />

--- a/tests/Sitecore.Horizon.Integration.Editor.Tests.UI/reqnroll.json
+++ b/tests/Sitecore.Horizon.Integration.Editor.Tests.UI/reqnroll.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schemas.reqnroll.net/reqnroll-config-latest.json",
+  "language": {
+    "feature": "en-US"
+  },
+  "trace": {
+    "stepDefinitionSkeletonStyle": "RegexAttribute"
+  }
+}

--- a/tests/Sitecore.Horizon.Integration.Editor.Tests.UI/specflow.json
+++ b/tests/Sitecore.Horizon.Integration.Editor.Tests.UI/specflow.json
@@ -1,5 +1,0 @@
-{
-  "language": {
-    "feature": "en-US"
-  }
-}


### PR DESCRIPTION
Replaces SpecFlow NuGet packages with Reqnroll equivalents in the Sitecore.Horizon.Integration.Editor.Tests.UI project.

Updates namespaces in C# files from TechTalk.SpecFlow to Reqnroll. Renames specflow.json to reqnroll.json and updates its schema and configuration (sets stepDefinitionSkeletonStyle to RegexAttribute).

Note: Automated update of step definition regex attributes was skipped due to limitations. Build is currently blocked by environment issues (NuGet auth, .NET 4.8 targeting pack) that need to be resolved manually.